### PR TITLE
Updating the Gitpod's discord server address

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ Gitpod is developed as an open core product under an [OSI-approved open source l
  - [Commit message convention](https://www.gitpod.io/docs/contribute/features-and-patches/commit-message-convention)
  - [Submitting a pull request](https://www.gitpod.io/docs/contribute/features-and-patches/submitting-a-pull-request)
 
- We ❤ the people who are involved in this project, and we’d love to help you with onboarding. Drop by the `#contributing` channel on the [Gitpod Discord server](https://www.gitpod.io/cla) and _ask for help_.
+ We ❤ the people who are involved in this project, and we’d love to help you with onboarding. Drop by the `#contributing` channel on the [Gitpod Discord server](https://www.gitpod.io/chat) and _ask for help_.


### PR DESCRIPTION
## Description
Fix: Broken link to the Discord server

## Related Issue(s)

I believe as similar and updated documentation is maintained on the GitPod docs website,  we should point this repo to link there instead. Specifically [GitPod Contribution Guidelines.  ](https://www.gitpod.io/docs/contribute/features-and-patches#contribute-features--patches)

Fixes #

## How to test

 the original link for gitpod chat gies 404. 

## Release Notes
NONE

## Documentation

* No
  * I believe, this file needs to be updated to point to the GitPod Documentation Website.
