### PR TITLE
Fix the broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Gitpod is developed as an open core product under an [OSI-approved open source l
  Gitpod has built-in the open for the last decade. Transparency is key and as a company Gitpod strives to be as open about as many things as possible. This refers to both developing Gitpod in the open (public issues, public roadmap, public milestones) as well as how employees interact on a personal level with other human beings. Gitpodders are strong believers in the benefits that an open culture provides. At Gitpod we are open-minded, inclusive, transparent, and curious. We always remain students of the game, not masters of the game.
 
  - [Contributor license agreement](https://www.gitpod.io/cla)
- - [Code Style](https://www.gitpod.io/docs/contribute/features-and-patches/code-style)
- - [Commit message convention](https://www.gitpod.io/docs/contribute/features-and-patches/commit-message-convention)
- - [Submitting a pull request](https://www.gitpod.io/docs/contribute/features-and-patches/submitting-a-pull-request)
+ - [Code Style](https://www.gitpod.io/docs/help/contribute/features-and-patches/code-style)
+ - [Commit message convention](https://www.gitpod.io/docs/help/contribute/features-and-patches/commit-message-convention)
+ - [Submitting a pull request](https://www.gitpod.io/docs/help/contribute/features-and-patches/submitting-a-pull-request)
 
  We ❤ the people who are involved in this project, and we’d love to help you with onboarding. Drop by the `#contributing` channel on the [Gitpod Discord server](https://www.gitpod.io/chat) and _ask for help_.


### PR DESCRIPTION
## Description
Links in the contributing guide redirects to a non existent page

## Related Issue(s)

<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/.github/issues/14

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
